### PR TITLE
Rename update

### DIFF
--- a/chromeio.py
+++ b/chromeio.py
@@ -455,9 +455,15 @@ with open(procmon_log_name, 'r') as csvfile:
             write_bytes = 0
             read_bytes = 0
             op = row[op_col_idx]
-            if op == 'IRP_MJ_SET_INFORMATION':
+            if (op == 'IRP_MJ_SET_INFORMATION' or
+                    op == 'SetRenameInformationFile'):
                 detail = ParseDetail(row[detail_col_idx])
-                if 'Type' in detail and detail['Type'] == 'SetRenameInformationFile':
+                # If the Detail column has a 'Type' field that is set to
+                # SetRenameInformationFile (the format used when op is equal to
+                # IRP_MJ_SET_INFORMATION) or if op is equal to
+                # SetRenameInformationFile (the new procmon format) then process
+                # the rename operation.
+                if detail.get('Type', op) == 'SetRenameInformationFile':
                     old_name = path
                     if True:
                         file_totals = ExtractFileTotalsFromCategory(old_name)

--- a/chromeio.py
+++ b/chromeio.py
@@ -455,8 +455,7 @@ with open(procmon_log_name, 'r') as csvfile:
             write_bytes = 0
             read_bytes = 0
             op = row[op_col_idx]
-            if (op == 'IRP_MJ_SET_INFORMATION' or
-                    op == 'SetRenameInformationFile'):
+            if op in ['IRP_MJ_SET_INFORMATION', 'SetRenameInformationFile']:
                 detail = ParseDetail(row[detail_col_idx])
                 # If the Detail column has a 'Type' field that is set to
                 # SetRenameInformationFile (the format used when op is equal to
@@ -473,10 +472,10 @@ with open(procmon_log_name, 'r') as csvfile:
                             category = GetCategory(new_name)
                             file_totals.path = new_name
                             category.AppendFileTotals(file_totals)
-            elif op == 'IRP_MJ_WRITE' or op == 'FASTIO_WRITE' or op == 'WriteFile':
+            elif op in ['IRP_MJ_WRITE', 'FASTIO_WRITE', 'WriteFile']:
                 detail = ParseDetail(row[detail_col_idx])
                 write_bytes = int(detail['Length'].replace(',', ''))
-            elif op == 'IRP_MJ_READ' or op == 'FASTIO_READ' or op == 'ReadFile':
+            elif op in ['IRP_MJ_READ', 'FASTIO_READ', 'ReadFile']:
                 detail = ParseDetail(row[detail_col_idx])
                 read_bytes = int(detail['Length'].replace(',', ''))
             if read_bytes or write_bytes:


### PR DESCRIPTION
This updates the rename tracking logic to work with the procmon files that I am getting with recent versions of procmon. The changes are fairly simple and I *think* that the old .csv files will still work, but the one example file I have is sufficiently malformed that even the original checked-in version can't load it (four strings end with a single slash before the closing quote, which is invalid, after fixing those a non-specific "ValueError: invalid \x escape").

I wasn't quite sure how to do the indentation of the multi-line if statement. The style guide suggested I should indent the second line by four, but that leaves the body on the same level which feels weird.